### PR TITLE
Prepare release distribution pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - "codex/**"
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: "1"
+
+jobs:
+  test:
+    name: Format, unit tests, and integration smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Show toolchain
+        run: rustc --version && cargo --version
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Run unit tests
+        run: cargo test
+
+      - name: Run integration smoke tests
+        run: bash integration-tests/run.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,10 @@ jobs:
 
           cargo_version="$(grep -m1 '^version = "' Cargo.toml | sed -E 's/version = "([^"]+)"/\1/')"
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            if [[ "${GITHUB_REF_NAME}" != "main" ]]; then
+              echo "Manual release publishing is only allowed from the main branch" >&2
+              exit 1
+            fi
             version="${INPUT_VERSION#v}"
           else
             version="${GITHUB_REF_NAME#v}"
@@ -173,7 +177,12 @@ jobs:
 
           for file in dist/*; do
             [[ -f "${file}" ]] || continue
-            aws s3 cp "${file}" "s3://${AWS_RELEASE_BUCKET}/${release_prefix}/v${version}/$(basename "${file}")" --no-progress
+            key="${release_prefix}/v${version}/$(basename "${file}")"
+            if aws s3api head-object --bucket "${AWS_RELEASE_BUCKET}" --key "${key}" >/dev/null 2>&1; then
+              echo "Refusing to overwrite existing artifact s3://${AWS_RELEASE_BUCKET}/${key}" >&2
+              exit 1
+            fi
+            aws s3 cp "${file}" "s3://${AWS_RELEASE_BUCKET}/${key}" --no-progress
           done
 
       - name: Publish release summary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,193 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version from Cargo.toml, with or without a leading v
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: "1"
+
+jobs:
+  prepare:
+    name: Resolve version and publish contract
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      aws_region: ${{ steps.meta.outputs.aws_region }}
+      release_prefix: ${{ steps.meta.outputs.release_prefix }}
+      s3_uri: ${{ steps.meta.outputs.s3_uri }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Resolve release metadata
+        id: meta
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          AWS_RELEASE_BUCKET: ${{ vars.AWS_RELEASE_BUCKET }}
+          AWS_RELEASE_PREFIX: ${{ vars.AWS_RELEASE_PREFIX }}
+          AWS_RELEASE_REGION: ${{ vars.AWS_RELEASE_REGION }}
+        run: |
+          set -euo pipefail
+
+          cargo_version="$(grep -m1 '^version = "' Cargo.toml | sed -E 's/version = "([^"]+)"/\1/')"
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            version="${INPUT_VERSION#v}"
+          else
+            version="${GITHUB_REF_NAME#v}"
+          fi
+
+          if [[ -z "${version}" ]]; then
+            echo "Unable to resolve release version" >&2
+            exit 1
+          fi
+          if [[ "${version}" != "${cargo_version}" ]]; then
+            echo "Release version ${version} does not match Cargo.toml version ${cargo_version}" >&2
+            exit 1
+          fi
+          if [[ -z "${AWS_RELEASE_BUCKET}" ]]; then
+            echo "Set repository variable AWS_RELEASE_BUCKET before publishing" >&2
+            exit 1
+          fi
+
+          release_prefix="${AWS_RELEASE_PREFIX:-evelin}"
+          aws_region="${AWS_RELEASE_REGION:-eu-west-1}"
+          s3_uri="s3://${AWS_RELEASE_BUCKET}/${release_prefix}/v${version}"
+
+          {
+            echo "version=${version}"
+            echo "aws_region=${aws_region}"
+            echo "release_prefix=${release_prefix}"
+            echo "s3_uri=${s3_uri}"
+          } >> "${GITHUB_OUTPUT}"
+
+  build:
+    name: Build ${{ matrix.label }} archive
+    needs: prepare
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: Linux
+            runner: ubuntu-latest
+            artifact_name: release-linux
+          - label: macOS
+            runner: macos-latest
+            artifact_name: release-macos
+          - label: Windows
+            runner: windows-latest
+            artifact_name: release-windows
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Show toolchain
+        shell: bash
+        run: |
+          rustc --version
+          cargo --version
+          rustc -vV
+
+      - name: Build release binary
+        shell: bash
+        run: cargo build --locked --release
+
+      - name: Package release archive
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_path="$(bash scripts/package-release.sh "${{ needs.prepare.outputs.version }}" dist)"
+          echo "artifact_path=${artifact_path}" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload packaged archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ steps.package.outputs.artifact_path }}
+          if-no-files-found: error
+
+  publish:
+    name: Publish archives to S3
+    needs:
+      - prepare
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download packaged archives
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: release-*
+          merge-multiple: true
+
+      - name: Verify publish configuration
+        shell: bash
+        env:
+          AWS_RELEASE_BUCKET: ${{ vars.AWS_RELEASE_BUCKET }}
+          AWS_RELEASE_ROLE_ARN: ${{ vars.AWS_RELEASE_ROLE_ARN }}
+        run: |
+          set -euo pipefail
+          : "${AWS_RELEASE_BUCKET:?Set repository variable AWS_RELEASE_BUCKET}"
+          : "${AWS_RELEASE_ROLE_ARN:?Set repository variable AWS_RELEASE_ROLE_ARN}"
+
+      - name: Generate checksum manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          sha256sum ./* > SHA256SUMS
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ needs.prepare.outputs.aws_region }}
+          mask-aws-account-id: true
+          role-to-assume: ${{ vars.AWS_RELEASE_ROLE_ARN }}
+
+      - name: Upload archives and checksums
+        shell: bash
+        env:
+          AWS_RELEASE_BUCKET: ${{ vars.AWS_RELEASE_BUCKET }}
+        run: |
+          set -euo pipefail
+          version="${{ needs.prepare.outputs.version }}"
+          release_prefix="${{ needs.prepare.outputs.release_prefix }}"
+
+          for file in dist/*; do
+            [[ -f "${file}" ]] || continue
+            aws s3 cp "${file}" "s3://${AWS_RELEASE_BUCKET}/${release_prefix}/v${version}/$(basename "${file}")" --no-progress
+          done
+
+      - name: Publish release summary
+        shell: bash
+        run: |
+          {
+            echo "## Published evelin artifacts"
+            echo
+            echo "Release prefix: \`${{ needs.prepare.outputs.s3_uri }}\`"
+            echo
+            echo "| File |"
+            echo "| --- |"
+            for file in dist/*; do
+              [[ -f "${file}" ]] || continue
+              echo "| $(basename "${file}") |"
+            done
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Bundled default template je v [core/src/eval-config.toml](/Users/jiri/projects/e
 
 ## Instalace z release artifactu
 
-Downstream agent asset repozitare muzou stahnout konkretni verzi pomoci [scripts/install-evelin.sh](/Users/jiri/.codex/worktrees/b4be/evelin/.worktrees/10-install-script/scripts/install-evelin.sh).
+Downstream agent asset repozitare muzou stahnout konkretni verzi pomoci [scripts/install-evelin.sh](./scripts/install-evelin.sh).
 
 ```bash
 ./scripts/install-evelin.sh 0.1.0
@@ -69,10 +69,11 @@ Downstream agent asset repozitare muzou stahnout konkretni verzi pomoci [scripts
 
 Skript:
 
-- detekuje podporovany OS/arch a vybere odpovidajici artifact
+- detekuje podporovany OS/arch a vybere odpovidajici artifact pro publikovane targety (`linux/x86_64`, `macOS/aarch64`)
 - stahne `SHA256SUMS` i konkretni archive
 - overi checksum pred instalaci
 - nainstaluje binarku do `~/.local/bin` nebo do `EVELIN_INSTALL_DIR`
+- na Windows zatim ocekava manualni stazeni publikovaneho `.zip` artifactu
 
 Konfigurace zdroje artifactu:
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,38 @@ Bundled default template je v [core/src/eval-config.toml](/Users/jiri/projects/e
 4. inline hodnoty v konkretnim eval configu
 5. `EVAL_CODEX_HOME_BASE_DIR`
 
+## Instalace z release artifactu
+
+Downstream agent asset repozitare muzou stahnout konkretni verzi pomoci [scripts/install-evelin.sh](/Users/jiri/.codex/worktrees/b4be/evelin/.worktrees/10-install-script/scripts/install-evelin.sh).
+
+```bash
+./scripts/install-evelin.sh 0.1.0
+```
+
+Skript:
+
+- detekuje podporovany OS/arch a vybere odpovidajici artifact
+- stahne `SHA256SUMS` i konkretni archive
+- overi checksum pred instalaci
+- nainstaluje binarku do `~/.local/bin` nebo do `EVELIN_INSTALL_DIR`
+
+Konfigurace zdroje artifactu:
+
+- `EVELIN_RELEASE_BASE_URL`:
+  - explicitni base URL, napriklad `https://s3.eu-west-1.amazonaws.com/my-bucket/evelin`
+- nebo odvozeni ze S3:
+  - `EVELIN_S3_BUCKET` povinny
+  - `EVELIN_S3_REGION` optional, default `eu-west-1`
+  - `EVELIN_S3_PREFIX` optional, default `evelin`
+
+Priklad pro downstream repo:
+
+```bash
+EVELIN_S3_BUCKET=my-release-bucket \
+EVELIN_S3_PREFIX=evelin \
+./scripts/install-evelin.sh v0.1.0
+```
+
 ## Vyvoj
 
 ```bash

--- a/docs/release-contract.md
+++ b/docs/release-contract.md
@@ -1,0 +1,65 @@
+# Release Contract
+
+This repository publishes versioned `evelin` binaries from GitHub Actions to S3.
+
+## Triggers
+
+- `push` tags matching `v*`
+- manual `workflow_dispatch` with a `version` input
+
+## Version Rules
+
+- The resolved workflow version must match `Cargo.toml`.
+- Manual input may be passed as `0.1.0` or `v0.1.0`.
+- A version mismatch fails the workflow before any upload happens.
+
+## Artifact Naming
+
+Each build job packages one host-specific release archive:
+
+- Unix hosts: `evelin-v<version>-<host-target>.tar.gz`
+- Windows hosts: `evelin-v<version>-<host-target>.zip`
+- Checksum manifest: `SHA256SUMS`
+
+Examples:
+
+- `evelin-v0.1.0-x86_64-unknown-linux-gnu.tar.gz`
+- `evelin-v0.1.0-aarch64-apple-darwin.tar.gz`
+- `evelin-v0.1.0-x86_64-pc-windows-msvc.zip`
+
+## S3 Layout
+
+Required repository variables:
+
+- `AWS_RELEASE_BUCKET`
+- `AWS_RELEASE_ROLE_ARN`
+
+Optional repository variables:
+
+- `AWS_RELEASE_PREFIX` default `evelin`
+- `AWS_RELEASE_REGION` default `eu-west-1`
+
+Published object layout:
+
+- `s3://<bucket>/<prefix>/v<version>/<artifact>`
+
+Examples:
+
+- `s3://my-release-bucket/evelin/v0.1.0/evelin-v0.1.0-x86_64-unknown-linux-gnu.tar.gz`
+- `s3://my-release-bucket/evelin/v0.1.0/SHA256SUMS`
+
+## Auth Model
+
+- GitHub Actions requests an OIDC token with `id-token: write`.
+- AWS auth is performed through `aws-actions/configure-aws-credentials`.
+- The IAM role should restrict the trusted repository/ref and only allow writes to the chosen bucket/prefix.
+
+## Failure Model
+
+The workflow fails if:
+
+- version resolution is empty or mismatched
+- the required AWS repository variables are missing
+- a runner fails to build or package its binary
+- checksum generation fails
+- S3 upload fails for any artifact

--- a/docs/release-contract.md
+++ b/docs/release-contract.md
@@ -5,7 +5,7 @@ This repository publishes versioned `evelin` binaries from GitHub Actions to S3.
 ## Triggers
 
 - `push` tags matching `v*`
-- manual `workflow_dispatch` with a `version` input
+- manual `workflow_dispatch` with a `version` input, but only when the workflow runs from `main`
 
 ## Version Rules
 
@@ -42,6 +42,7 @@ Optional repository variables:
 Published object layout:
 
 - `s3://<bucket>/<prefix>/v<version>/<artifact>`
+- existing objects under the version path are treated as immutable and the workflow fails instead of overwriting them
 
 Examples:
 

--- a/integration-tests/fixtures/scope-to-acceptance-project/skills/scope-to-acceptance/SKILL.md
+++ b/integration-tests/fixtures/scope-to-acceptance-project/skills/scope-to-acceptance/SKILL.md
@@ -1,0 +1,12 @@
+## Workflow
+
+Use this integration fixture to validate schema and gate lint flows.
+
+## Output Contract
+
+- Outcome Statement
+- Scope (in)
+
+## Gate Rules
+
+- Include the required headings above.

--- a/integration-tests/fixtures/scope-to-acceptance-project/tests/src/skills/scope-to-acceptance/suite.eval.yaml
+++ b/integration-tests/fixtures/scope-to-acceptance-project/tests/src/skills/scope-to-acceptance/suite.eval.yaml
@@ -1,0 +1,18 @@
+eval_type: skill
+skill: scope-to-acceptance
+skill_path: skills/scope-to-acceptance/SKILL.md
+gate_requirements:
+  required_snippets:
+    - "## Workflow"
+    - "## Output Contract"
+    - "## Gate Rules"
+grader: markers
+rate: 0.5
+cases:
+  - id: explicit
+    prompt: use the skill
+    expected:
+      must_include:
+        - "Outcome Statement:"
+        - "Scope (in):"
+      must_not_include: []

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+FIXTURE_ROOT="${SCRIPT_DIR}/fixtures/scope-to-acceptance-project"
+OUT_DIR="$(mktemp -d)"
+trap 'rm -rf "${OUT_DIR}"' EXIT
+
+SCHEMA_CONFIG="${FIXTURE_ROOT}/tests/src/skills/scope-to-acceptance/suite.eval.yaml"
+SCHEMA_OUT="${OUT_DIR}/schema.json"
+GATE_OUT="${OUT_DIR}/gate.json"
+
+echo "Running schema-lint against integration fixture"
+cargo run --manifest-path "${REPO_ROOT}/Cargo.toml" -- \
+  schema-lint \
+  --config "${SCHEMA_CONFIG}" \
+  --out "${SCHEMA_OUT}"
+
+echo "Running gate-lint against integration fixture"
+cargo run --manifest-path "${REPO_ROOT}/Cargo.toml" -- \
+  gate-lint \
+  --requirements "${SCHEMA_CONFIG}" \
+  --root "${FIXTURE_ROOT}" \
+  --out "${GATE_OUT}"
+
+grep -q '"verdict": "pass"' "${SCHEMA_OUT}"
+grep -q '"verdict": "pass"' "${GATE_OUT}"
+
+echo "Integration smoke tests passed"

--- a/scripts/install-evelin.sh
+++ b/scripts/install-evelin.sh
@@ -96,9 +96,10 @@ detect_target() {
 
   case "${os}:${arch}" in
     linux:x86_64) printf 'x86_64-unknown-linux-gnu\n' ;;
-    linux:aarch64) printf 'aarch64-unknown-linux-gnu\n' ;;
-    macos:x86_64) printf 'x86_64-apple-darwin\n' ;;
     macos:aarch64) printf 'aarch64-apple-darwin\n' ;;
+    linux:aarch64|macos:x86_64)
+      fail "unsupported platform combination: ${os}/${arch}; published install targets are linux/x86_64 and macOS/aarch64"
+      ;;
     *)
       fail "unsupported platform combination: ${os}/${arch}"
       ;;

--- a/scripts/install-evelin.sh
+++ b/scripts/install-evelin.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: install-evelin.sh <version>
+
+Install a specific evelin release archive into a local bin directory.
+
+Environment:
+  EVELIN_VERSION            Default version if no positional argument is given
+  EVELIN_INSTALL_DIR        Target directory, default: $HOME/.local/bin
+  EVELIN_RELEASE_BASE_URL   Full base URL that contains /v<version>/ artifacts
+  EVELIN_S3_BUCKET          Bucket name used to derive the base URL when EVELIN_RELEASE_BASE_URL is unset
+  EVELIN_S3_REGION          Region for derived S3 URL, default: eu-west-1
+  EVELIN_S3_PREFIX          Prefix for derived S3 URL, default: evelin
+EOF
+}
+
+fail() {
+  echo "install-evelin: $*" >&2
+  exit 1
+}
+
+need_fetch_tool() {
+  if command -v curl >/dev/null 2>&1 || command -v wget >/dev/null 2>&1; then
+    return 0
+  fi
+  fail "curl or wget is required"
+}
+
+fetch() {
+  local url="$1"
+  local destination="$2"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl --fail --silent --show-error --location --retry 3 --output "${destination}" "${url}"
+    return 0
+  fi
+  if command -v wget >/dev/null 2>&1; then
+    wget -qO "${destination}" "${url}"
+    return 0
+  fi
+
+  fail "curl or wget is required"
+}
+
+verify_checksum() {
+  local work_dir="$1"
+  local manifest="$2"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    (
+      cd "${work_dir}"
+      sha256sum -c "${manifest}" >/dev/null
+    )
+    return 0
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    (
+      cd "${work_dir}"
+      shasum -a 256 -c "${manifest}" >/dev/null
+    )
+    return 0
+  fi
+
+  fail "sha256sum or shasum is required to verify downloads"
+}
+
+detect_target() {
+  local os
+  local arch
+
+  os="$(uname -s)"
+  arch="$(uname -m)"
+
+  case "${os}" in
+    Linux) os="linux" ;;
+    Darwin) os="macos" ;;
+    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+      fail "Windows shell installation is not supported; download the published zip artifact manually"
+      ;;
+    *)
+      fail "unsupported operating system: ${os}"
+      ;;
+  esac
+
+  case "${arch}" in
+    x86_64|amd64) arch="x86_64" ;;
+    arm64|aarch64) arch="aarch64" ;;
+    *)
+      fail "unsupported CPU architecture: ${arch}"
+      ;;
+  esac
+
+  case "${os}:${arch}" in
+    linux:x86_64) printf 'x86_64-unknown-linux-gnu\n' ;;
+    linux:aarch64) printf 'aarch64-unknown-linux-gnu\n' ;;
+    macos:x86_64) printf 'x86_64-apple-darwin\n' ;;
+    macos:aarch64) printf 'aarch64-apple-darwin\n' ;;
+    *)
+      fail "unsupported platform combination: ${os}/${arch}"
+      ;;
+  esac
+}
+
+resolve_base_url() {
+  if [[ -n "${EVELIN_RELEASE_BASE_URL:-}" ]]; then
+    printf '%s\n' "${EVELIN_RELEASE_BASE_URL%/}"
+    return 0
+  fi
+
+  local bucket="${EVELIN_S3_BUCKET:-}"
+  local region="${EVELIN_S3_REGION:-eu-west-1}"
+  local prefix="${EVELIN_S3_PREFIX:-evelin}"
+
+  if [[ -z "${bucket}" ]]; then
+    fail "set EVELIN_RELEASE_BASE_URL or EVELIN_S3_BUCKET"
+  fi
+
+  printf 'https://s3.%s.amazonaws.com/%s/%s\n' "${region}" "${bucket}" "${prefix}"
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+VERSION="${1:-${EVELIN_VERSION:-}}"
+if [[ -z "${VERSION}" ]]; then
+  usage >&2
+  fail "missing version argument"
+fi
+VERSION="${VERSION#v}"
+
+need_fetch_tool
+
+TARGET="$(detect_target)"
+ARCHIVE_NAME="evelin-v${VERSION}-${TARGET}.tar.gz"
+BASE_URL="$(resolve_base_url)"
+RELEASE_URL="${BASE_URL}/v${VERSION}"
+INSTALL_DIR="${EVELIN_INSTALL_DIR:-${HOME}/.local/bin}"
+TMP_DIR="$(mktemp -d)"
+trap 'find "${TMP_DIR}" -type f -delete >/dev/null 2>&1 || true; find "${TMP_DIR}" -type d -empty -delete >/dev/null 2>&1 || true' EXIT
+
+CHECKSUMS_PATH="${TMP_DIR}/SHA256SUMS"
+ARCHIVE_PATH="${TMP_DIR}/${ARCHIVE_NAME}"
+FILTERED_MANIFEST="${TMP_DIR}/SHA256SUMS.filtered"
+
+fetch "${RELEASE_URL}/SHA256SUMS" "${CHECKSUMS_PATH}"
+fetch "${RELEASE_URL}/${ARCHIVE_NAME}" "${ARCHIVE_PATH}"
+
+if ! grep -F "./${ARCHIVE_NAME}" "${CHECKSUMS_PATH}" > "${FILTERED_MANIFEST}"; then
+  fail "checksum entry for ${ARCHIVE_NAME} not found in SHA256SUMS"
+fi
+
+verify_checksum "${TMP_DIR}" "$(basename "${FILTERED_MANIFEST}")"
+
+tar -xzf "${ARCHIVE_PATH}" -C "${TMP_DIR}"
+
+if [[ ! -f "${TMP_DIR}/evelin" ]]; then
+  fail "archive ${ARCHIVE_NAME} did not contain evelin binary"
+fi
+
+mkdir -p "${INSTALL_DIR}"
+install -m 0755 "${TMP_DIR}/evelin" "${INSTALL_DIR}/evelin"
+
+echo "Installed evelin ${VERSION} to ${INSTALL_DIR}/evelin"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+  echo "usage: $0 <version> <out-dir> [binary-path]" >&2
+  exit 1
+fi
+
+VERSION="$1"
+OUT_DIR="$2"
+BINARY_PATH="${3:-target/release/evelin}"
+HOST_TARGET="$(rustc -vV | sed -n 's/^host: //p')"
+
+if [[ -z "${HOST_TARGET}" ]]; then
+  echo "Unable to determine Rust host target" >&2
+  exit 1
+fi
+
+mkdir -p "${OUT_DIR}"
+
+archive_base="evelin-v${VERSION}-${HOST_TARGET}"
+
+if [[ "${HOST_TARGET}" == *windows* ]]; then
+  if [[ ! -f "${BINARY_PATH}.exe" ]]; then
+    echo "Missing Windows binary at ${BINARY_PATH}.exe" >&2
+    exit 1
+  fi
+
+  archive_path="${OUT_DIR}/${archive_base}.zip"
+  if command -v 7z >/dev/null 2>&1; then
+    7z a -tzip "${archive_path}" "${BINARY_PATH}.exe" >/dev/null
+  else
+    echo "Missing 7z; cannot create Windows archive" >&2
+    exit 1
+  fi
+else
+  if [[ ! -f "${BINARY_PATH}" ]]; then
+    echo "Missing Unix binary at ${BINARY_PATH}" >&2
+    exit 1
+  fi
+
+  archive_path="${OUT_DIR}/${archive_base}.tar.gz"
+  tar -C "$(dirname "${BINARY_PATH}")" -czf "${archive_path}" "$(basename "${BINARY_PATH}")"
+fi
+
+printf '%s\n' "${archive_path}"


### PR DESCRIPTION
## Summary
- add CI workflow for formatting, unit tests, and integration smoke coverage
- add release workflow for versioned cross-platform artifacts, checksum generation, and S3 publishing via AWS OIDC
- add installer script for downstream agent asset repositories and document the release contract

## Issue Links
- closes #7
- implements #8
- implements #9
- implements #10

## Validation
- `cargo fmt --check`
- `cargo test`
- `bash integration-tests/run.sh`
- `cargo build --locked --release`
- `bash scripts/package-release.sh 0.1.0 dist-check`
- `bash scripts/install-evelin.sh 0.1.0` against a local file-based release mirror

## Follow-up Setup
- configure repository variables `AWS_RELEASE_BUCKET` and `AWS_RELEASE_ROLE_ARN`
- optionally configure `AWS_RELEASE_PREFIX` and `AWS_RELEASE_REGION`
- ensure the AWS OIDC trust policy is restricted to this repository and allowed refs, with S3 write access scoped to the release prefix